### PR TITLE
Add --force option to helm push command

### DIFF
--- a/src/jobs/helm_push.yaml
+++ b/src/jobs/helm_push.yaml
@@ -36,4 +36,4 @@ steps:
 
         echo "Adding '<< parameters.charts_repo_url >>'"
         helm repo add --username "${CHARTS_REPO_USER}" --password "${CHARTS_REPO_PASS}" codacy << parameters.charts_repo_url >>
-        helm push ${HELM_DIR}/${CHART_NAME} codacy
+        helm push ${HELM_DIR}/${CHART_NAME} codacy --force

--- a/src/jobs/helm_push.yaml
+++ b/src/jobs/helm_push.yaml
@@ -14,6 +14,9 @@ parameters:
     type: string
     description: "charts repo domain ssm parameter"
     default: "https://charts.codacy.com/unstable"
+  push_options:
+    type: string
+    description: "helm push options to be added"
 
 environment:
   CHART_NAME: << parameters.chart_name >>
@@ -36,4 +39,4 @@ steps:
 
         echo "Adding '<< parameters.charts_repo_url >>'"
         helm repo add --username "${CHARTS_REPO_USER}" --password "${CHARTS_REPO_PASS}" codacy << parameters.charts_repo_url >>
-        helm push ${HELM_DIR}/${CHART_NAME} codacy --force
+        helm push ${HELM_DIR}/${CHART_NAME} codacy << parameters.push_options >>


### PR DESCRIPTION
This change allows us to re-run the same workflow multiple times without having to manually delete charts from the chart museum