### PR TITLE
[Don't Merge] Add orb to run codacy-plugins-test native-image

### DIFF
--- a/src/jobs/run_codacy_plugins_test.yml
+++ b/src/jobs/run_codacy_plugins_test.yml
@@ -14,22 +14,23 @@ steps:
   - attach_workspace:
       at: ~/
   - restore_cache:
-          key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
-      - attach_workspace:
-          at: ~/
-      - run:
-          command: |
-            mkdir -p codacy-plugins-test
-            cd codacy-plugins-test
-            FILENAME=codacy-plugins-test-$CODACY_PLUGINS_TEST_VERSION
-            if [ ! -f "$FILENAME" ]; then
-              wget https://bintray.com/codacy/Binaries/download_file?file_path=$CODACY_PLUGINS_TEST_VERSION%2Fcodacy-plugins-test-linux -O $FILENAME
-              chmod +x $FILENAME
-            fi
-            docker load --input ~/workdir/docker-image.tar
-            ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
-            ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
-      - save_cache:
-          key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
-          paths:
-            - ~/codacy-plugins-test
+      key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+  - attach_workspace:
+      at: ~/
+  - run:
+      command: |
+        mkdir -p codacy-plugins-test
+        cd codacy-plugins-test
+        FILENAME=codacy-plugins-test-$CODACY_PLUGINS_TEST_VERSION
+        LINK="https://bintray.com/codacy/Binaries/download_file?file_path=$CODACY_PLUGINS_TEST_VERSION%2Fcodacy-plugins-test-linux"
+        if [ ! -f "$FILENAME" ]; then
+          wget $LINK -O $FILENAME
+          chmod +x $FILENAME
+        fi
+        docker load --input ~/workdir/docker-image.tar
+        ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
+        ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
+  - save_cache:
+      key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+      paths:
+        - ~/codacy-plugins-test

--- a/src/jobs/run_codacy_plugins_test.yml
+++ b/src/jobs/run_codacy_plugins_test.yml
@@ -1,0 +1,35 @@
+description: "Runs codacy-plugins-test on a tool"
+
+executor: machine
+
+parameters:
+  codacy_plugins_test_version:
+    type: string
+    description: "codacy-plugins-test version"
+
+environment:
+  CODACY_PLUGINS_TEST_VERSION: << parameters.codacy_plugins_test_version >>
+
+steps:
+  - attach_workspace:
+      at: ~/
+  - restore_cache:
+          key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+      - attach_workspace:
+          at: ~/
+      - run:
+          command: |
+            mkdir -p codacy-plugins-test
+            cd codacy-plugins-test
+            FILENAME=codacy-plugins-test-$CODACY_PLUGINS_TEST_VERSION
+            if [ ! -f "$FILENAME" ]; then
+              wget https://bintray.com/codacy/Binaries/download_file?file_path=$CODACY_PLUGINS_TEST_VERSION%2Fcodacy-plugins-test-linux -O $FILENAME
+              chmod +x $FILENAME
+            fi
+            docker load --input ~/workdir/docker-image.tar
+            ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
+            ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
+      - save_cache:
+          key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+          paths:
+            - ~/codacy-plugins-test

--- a/src/jobs/run_codacy_plugins_test.yml
+++ b/src/jobs/run_codacy_plugins_test.yml
@@ -6,6 +6,18 @@ parameters:
   version:
     type: string
     description: "codacy-plugins-test version"
+  run_json_tests:
+    type: boolean
+    default: true
+    description: "Run 'json' tests in codacy-plugins-test"
+  run_pattern_tests:
+    type: boolean
+    default: true
+    description: "Run 'pattern' tests in codacy-plugins-test"
+  run_plugin_tests:
+    type: boolean
+    default: false
+    description: "Run 'plugin' tests in codacy-plugins-test"
 
 steps:
   - attach_workspace:
@@ -25,8 +37,15 @@ steps:
           chmod +x $FILENAME
         fi
         docker load --input ~/workdir/docker-image.tar
-        ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
-        ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
+        if << parameters.run_json_tests >> ; then
+          ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
+        fi
+        if << parameters.run_pattern_tests >> ; then
+          ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
+        fi
+        if << parameters.run_plugin_tests >> ; then
+          ./$FILENAME plugin $CIRCLE_PROJECT_REPONAME:latest
+        fi
   - save_cache:
       key: codacy-plugins-test-cache-<< parameters.version >>
       paths:

--- a/src/jobs/run_codacy_plugins_test.yml
+++ b/src/jobs/run_codacy_plugins_test.yml
@@ -3,26 +3,23 @@ description: "Runs codacy-plugins-test on a tool"
 executor: machine
 
 parameters:
-  codacy_plugins_test_version:
+  version:
     type: string
     description: "codacy-plugins-test version"
-
-environment:
-  CODACY_PLUGINS_TEST_VERSION: << parameters.codacy_plugins_test_version >>
 
 steps:
   - attach_workspace:
       at: ~/
   - restore_cache:
-      key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+      key: codacy-plugins-test-cache-<< parameters.version >>
   - attach_workspace:
       at: ~/
   - run:
       command: |
         mkdir -p codacy-plugins-test
         cd codacy-plugins-test
-        FILENAME=codacy-plugins-test-$CODACY_PLUGINS_TEST_VERSION
-        LINK="https://bintray.com/codacy/Binaries/download_file?file_path=$CODACY_PLUGINS_TEST_VERSION%2Fcodacy-plugins-test-linux"
+        FILENAME=codacy-plugins-test-<< parameters.version >>
+        LINK="https://bintray.com/codacy/Binaries/download_file?file_path=<< parameters.version >>%2Fcodacy-plugins-test-linux"
         if [ ! -f "$FILENAME" ]; then
           wget $LINK -O $FILENAME
           chmod +x $FILENAME
@@ -31,6 +28,6 @@ steps:
         ./$FILENAME json $CIRCLE_PROJECT_REPONAME:latest
         ./$FILENAME pattern $CIRCLE_PROJECT_REPONAME:latest
   - save_cache:
-      key: codacy-plugins-test-cache-$CODACY_PLUGINS_TEST_VERSION
+      key: codacy-plugins-test-cache-<< parameters.version >>
       paths:
         - ~/codacy-plugins-test


### PR DESCRIPTION
This PR adds a orb to run codacy-plugins-test native-image in a tool repository.
The goal is to cache the binary when it's downloaded to a cache versioned by the binary version.
I'm using workspaces to get the docker image of the tool generated in the other steps.