### PR TITLE
fix: Set OpenJDK before running sbt tasks

### DIFF
--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -55,6 +55,9 @@ steps:
         cat >> ~/.aws/credentials \<< EOF
         << parameters.credentials_file_content >>
         EOF
+  - run:
+      name: Set OpenJdk
+      command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
   - sbt_cached:
       cmd: << parameters.cmd >>
   - when:


### PR DESCRIPTION
This fixes the certificates problem:
```
[error] Server access Error: Received fatal alert: handshake_failure url=https://repo.eclipse.org/content/groups/releases/com/codacy/database_2.11/15.3.0/database_2.11-15.3.0.pom
```
you might be experiencing in CIs