### PR TITLE
fix: Sbt caching

### DIFF
--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -16,7 +16,7 @@ parameters:
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
-    default: sbt-cache-022020
+    default: sbt-cache-032020
 
 steps:
 
@@ -31,12 +31,18 @@ steps:
       condition: <<parameters.cmd_name>>
       steps:
         - run:
+            name: Unpacking Caches
+            command: if [[ -f "$HOME/targets.tar.gz" ]]; then echo "unpacking cache" && tar -xf ~/targets.tar.gz; else echo "no cache found"; fi
+        - run:
             name: << parameters.cmd_name >>
             command: << parameters.cmd >>
 
   - unless:
       condition: <<parameters.cmd_name>>
       steps:
+        - run:
+            name: Unpacking Caches
+            command: if [[ -f "$HOME/targets.tar.gz" ]]; then echo "unpacking cache" && tar -xf ~/targets.tar.gz; else echo "no cache found"; fi
         - run:
             name: SBT command - << parameters.cmd >>
             command: << parameters.cmd >>
@@ -50,6 +56,8 @@ steps:
               set +eo pipefail
               find $HOME/.sbt -name "*.lock" | xargs rm | true
               find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm | true
+              find -name target -exec tar -zcf ~/targets.tar.gz -H posix {} + | true
+              find -name target -exec rm -r {} + | true
 
         - save_cache:
             key: << parameters.cache_prefix >>-{{ .Branch }}-{{ checksum "build.sbt" }}-{{ .Environment.CIRCLE_SHA1 }}
@@ -58,13 +66,4 @@ steps:
               - "~/.sbt"
               - "~/.m2"
               - "~/.cache"
-              - 'target'
-              - '*/target'
-              - '*/*/target'
-              - '*/*/*/target'
-              - '*/*/*/*/target'
-              - '*/*/*/*/*/*/target'
-              - '*/*/*/*/*/*/*/target'
-              - '*/*/*/*/*/*/*/*/target'
-              - '*/*/*/*/*/*/*/*/*/target'
-              - '*/*/*/*/*/*/*/*/*/*/target'
+              - "~/targets.tar.gz"

--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -32,7 +32,12 @@ steps:
       steps:
         - run:
             name: Unpacking Caches
-            command: if [[ -f "$HOME/targets.tar.gz" ]]; then echo "unpacking cache" && tar -xf ~/targets.tar.gz; else echo "no cache found"; fi
+            command: |
+              if [[ -f "$HOME/targets.tar.gz" ]]; then
+                echo "unpacking cache" && tar -xf ~/targets.tar.gz
+              else
+                echo "no cache found"
+              fi
         - run:
             name: << parameters.cmd_name >>
             command: << parameters.cmd >>
@@ -42,7 +47,12 @@ steps:
       steps:
         - run:
             name: Unpacking Caches
-            command: if [[ -f "$HOME/targets.tar.gz" ]]; then echo "unpacking cache" && tar -xf ~/targets.tar.gz; else echo "no cache found"; fi
+            command: |
+              if [[ -f "$HOME/targets.tar.gz" ]]; then
+                echo "unpacking cache" && tar -xf ~/targets.tar.gz
+              else
+                echo "no cache found"
+              fi
         - run:
             name: SBT command - << parameters.cmd >>
             command: << parameters.cmd >>
@@ -56,6 +66,8 @@ steps:
               set +eo pipefail
               find $HOME/.sbt -name "*.lock" | xargs rm | true
               find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm | true
+              # Workaround for this Sbt issue in CircleCI
+              # https://github.com/sbt/sbt/issues/4168
               find -name target -exec tar -zcf ~/targets.tar.gz -H posix {} + | true
               find -name target -exec rm -r {} + | true
 

--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -69,7 +69,7 @@ steps:
               # Workaround for this Sbt issue in CircleCI
               # https://github.com/sbt/sbt/issues/4168
               find -name target -type d -exec tar -zcf ~/targets.tar.gz -H posix {} + | true
-              find -name target -exec rm -r {} + | true
+              find -name target -type d -exec rm -r {} + | true
 
         - save_cache:
             key: << parameters.cache_prefix >>-{{ .Branch }}-{{ checksum "build.sbt" }}-{{ .Environment.CIRCLE_SHA1 }}

--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -68,7 +68,7 @@ steps:
               find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm | true
               # Workaround for this Sbt issue in CircleCI
               # https://github.com/sbt/sbt/issues/4168
-              find -name target -exec tar -zcf ~/targets.tar.gz -H posix {} + | true
+              find -name target -type d -exec tar -zcf ~/targets.tar.gz -H posix {} + | true
               find -name target -exec rm -r {} + | true
 
         - save_cache:

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -9,7 +9,7 @@ parameters:
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
-    default: sbt-new-cache
+    default: sbt-cache-032020
   aws_profile:
     description: "The AWS profile to be used"
     type: string


### PR DESCRIPTION
I finally discovered one of the reasons for the caches to be not working in most of our CircleCI setups:
https://github.com/sbt/sbt/issues/4168

The issue is still open and I'm pretty sure that this is not a final fix, rather is an improvement.
e.g.:
https://circleci.com/workflow-run/5c10aea5-7eba-4bb0-ae03-1f3e52b7f5da
the `populate_cahe_and_compile` step got a 7 minutes boost, but the tests are still taking almost the same time as before.