### PR TITLE
fix: Do not compress targets on osx

### DIFF
--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -67,11 +67,6 @@ steps:
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:
-        - run:
-            name: Compressing targets
-            command: |
-              find -name target -type d -exec tar -zcf targets.tar.gz -H posix {} + | true
-              find -name target -type d -exec rm -r {} + | true
         - persist_to_workspace:
             root: ~/workdir
             paths:


### PR DESCRIPTION
Usually we need to cache only specific artifacts produced on OsX is irrelevant to compress the targets and it fails on ci.