### PR TITLE
fix: add sleep between trigger and polling

### DIFF
--- a/src/jobs/deploy_to_selfhosted.yml
+++ b/src/jobs/deploy_to_selfhosted.yml
@@ -58,4 +58,3 @@ steps:
             echo "Remote workflow $workflowID execution failed. - $workflowURL"
             exit 1
         fi
-


### PR DESCRIPTION
Not sleeping in between the trigger and the pooling would cause the returned URL to be invalid.