### PR TITLE
fix: Make helm poll self hosted helm3 compliant

### DIFF
--- a/src/executors/do.yml
+++ b/src/executors/do.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run Digital Ocean commands
 
 docker:
-  - image: codacy/ci-do:0.6.0
+  - image: codacy/ci-do:1.6.1
 
 working_directory: ~/workdir

--- a/src/executors/do.yml
+++ b/src/executors/do.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run Digital Ocean commands
 
 docker:
-  - image: codacy/ci-do:1.6.1
+  - image: codacy/ci-do:1.6.4
 
 working_directory: ~/workdir

--- a/src/jobs/deploy_to_selfhosted.yml
+++ b/src/jobs/deploy_to_selfhosted.yml
@@ -2,6 +2,12 @@ description: "A job to deploy latest dev components to self-hosted"
 
 executor: do
 
+parameters:
+  environment:
+    description: The environment to poll (dev/sandbox/release).
+    type: string
+    default: "dev"
+
 steps:
   - deploy:
       name: Set cluster to digital ocean
@@ -11,7 +17,7 @@ steps:
   - deploy:
       name: Poll for installation availability
       command: |
-        helm poll -r codacy
+        helm poll -r codacy-<< parameters.environment >>
   - deploy:
       name: Trigger workflow to deploy dev components
       command: |

--- a/src/jobs/deploy_to_selfhosted.yml
+++ b/src/jobs/deploy_to_selfhosted.yml
@@ -3,10 +3,14 @@ description: "A job to deploy latest dev components to self-hosted"
 executor: do
 
 parameters:
-  environment:
-    description: The environment to poll (dev/sandbox/release).
+  release:
+    description: The helm release name to be installed.
     type: string
-    default: "dev"
+    default: "codacy-dev"
+  namespace:
+    description: The target namespace for the release.
+    type: string
+    default: "codacy-dev"
 
 steps:
   - deploy:
@@ -17,7 +21,7 @@ steps:
   - deploy:
       name: Poll for installation availability
       command: |
-        helm poll -r codacy-<< parameters.environment >> -n codacy-<< parameters.environment >>
+        helm poll -r << parameters.release >> -n << parameters.namespace >>
   - deploy:
       name: Trigger workflow to deploy dev components
       command: |

--- a/src/jobs/deploy_to_selfhosted.yml
+++ b/src/jobs/deploy_to_selfhosted.yml
@@ -17,7 +17,7 @@ steps:
   - deploy:
       name: Poll for installation availability
       command: |
-        helm poll -r codacy-<< parameters.environment >>
+        helm poll -r codacy-<< parameters.environment >> -n codacy-<< parameters.environment >>
   - deploy:
       name: Trigger workflow to deploy dev components
       command: |


### PR DESCRIPTION
The latest ci-do image consumes helm3 and installs the latest helm poll plugin as well.
