### PR TITLE
fix: Use force delete for targets directories

### DIFF
--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -98,7 +98,7 @@ steps:
             name: Compressing targets
             command: |
               find -name target -type d -exec tar -zcf targets.tar.gz -H posix {} + | true
-              find -name target -type d -exec rm -r {} + | true
+              find -name target -type d -exec rm -rf {} + | true
         - persist_to_workspace:
             root: ~/workdir
             paths:


### PR DESCRIPTION
Sometimes the target directory delete step fails with
```bash
rm: cannot remove './.../target': No such file or directory
```
like [here](https://app.circleci.com/pipelines/github/codacy/codacy-plugins/55/workflows/e4eb228a-4ecb-44c0-ba00-f60dce8a8139/jobs/118).

With this patch it forces the deletion without returning errors in case of the files to delete don't exist.

Here same PR passes using this patch: https://app.circleci.com/pipelines/github/codacy/codacy-plugins/65/workflows/7f0fab17-6fb4-4935-a8d4-856026098c05/jobs/138