### PR TITLE
clean: Change cache prefix for a global cleanup

### DIFF
--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -16,7 +16,7 @@ parameters:
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
-    default: sbt-cache-032020
+    default: sbt-cache-072020
   store_test_results_path:
     description: "The path to search for test results to upload to CircleCI"
     type: string

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -9,7 +9,7 @@ parameters:
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
-    default: sbt-cache-032020
+    default: sbt-cache-072020
   aws_profile:
     description: "The AWS profile to be used"
     type: string

--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -9,7 +9,7 @@ parameters:
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
-    default: sbt-osx-cache-032020
+    default: sbt-osx-cache-072020
   aws_profile:
     description: "The AWS profile to be used"
     type: string


### PR DESCRIPTION
Caches are getting very big. In codacy-worker the build-up
of downloaded dependencies is more than 2Gb that slows up
the CI a lot.