### PR TITLE
feature: Add save_cache parameter to sbt job :breaking:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.0.0
+
+Changed the default behaviour of the `sbt` job regarding caches.
+To upgrade you need to add the `save_cache: true` parameter to the
+first `codacy/sbt` job in your workflow, usually `populate_cache`.
+If not the caches will not be saved.
+
 ## 2.0.0
 
 Changed persist and attach of workspace to use the root of the `working_directory`.

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -32,6 +32,10 @@ parameters:
     description: "Whether to persist the workspace or not at the end of the job"
     type: boolean
     default: false
+  save_cache:
+    description: "Whether to save the cache or not at the end of the job"
+    type: boolean
+    default: true
   store_test_results:
     description: "Whether to upload the test results back to CircleCI"
     type: boolean
@@ -82,6 +86,7 @@ steps:
         - sbt_cached:
             cmd: << parameters.cmd >>
             cache_prefix: << parameters.cache_prefix >>
+            save_cache: << parameters.save_cache >>
             store_test_results_path: ~/workdir
 
   - unless:
@@ -90,6 +95,7 @@ steps:
         - sbt_cached:
             cmd: << parameters.cmd >>
             cache_prefix: << parameters.cache_prefix >>
+            save_cache: << parameters.save_cache >>
 
   - when:
       condition: << parameters.persist_to_workspace >>

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -35,7 +35,7 @@ parameters:
   save_cache:
     description: "Whether to save the cache or not at the end of the job"
     type: boolean
-    default: true
+    default: false
   store_test_results:
     description: "Whether to upload the test results back to CircleCI"
     type: boolean


### PR DESCRIPTION
Currently we spend time to compress and clean the caches every time, even when we don't actually save it.
This PR makes it configurable so the CI does the compression step only when needed.

## Problem example

![Example](https://user-images.githubusercontent.com/5793054/87696517-331dd580-c791-11ea-969c-e3758cf298ba.png)
