### PR TITLE
bump: Updated ci-do image version on executor

### DIFF
--- a/src/executors/do.yml
+++ b/src/executors/do.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run Digital Ocean commands
 
 docker:
-  - image: codacy/ci-do:1.6.4
+  - image: codacy/ci-do:1.8.1
 
 working_directory: ~/workdir


### PR DESCRIPTION
This bump includes a bump for the shipped helm version, which should resolve the ```Error: Kubernetes cluster unreachable: the server has asked for the client to provide credentials``` error that we have been getting.