### PR TITLE
fix: Call brew update explicitly to fix Bintray dependency

### DIFF
--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -47,7 +47,11 @@ steps:
       name: Download and install sbt
       environment:
         HOMEBREW_NO_AUTO_UPDATE: 1
-      command: brew install sbt
+      command: |
+        # Call brew update explicitly until Circle CI update their images,
+        # see https://github.com/Homebrew/brew/issues/11123
+        brew update
+        brew install sbt
   - run:
       name: Setup AWS Credentials
       command: |


### PR DESCRIPTION
**TL/DR:** The version of Homebrew on Circle CI images is outdated (2.2.2 from over a year ago) and has an issue that prevents the correct auto-update, necessary for fetching OpenJDK from the correct mirror and thus avoiding Bintray.



Workflows using this Orb [are failing](https://app.circleci.com/pipelines/github/codacy/codacy-coverage-reporter/920/workflows/01517e8d-fea5-499c-943a-c331c7f54ca3/jobs/7995/steps) because OpenJDK had a dependency from Bintray:

```
brew install sbt

...

==> Downloading https://homebrew.bintray.com/openjdk-15.0.2.catalina.bottle.tar.
##O#- #                                                                       
curl: (22) The requested URL returned error: 404 Not Found
Trying a mirror...
==> Downloading https://ghcr.io/v2/homebrew/core/openjdk-15.0.2.catalina.bottle.
==> Downloading from https://github.com/-/v2/packages/container/package/homebrew
##O#- #                                                                       
curl: (22) The requested URL returned error: 404 
Error: Failed to download resource "openjdk"
Download failed: https://ghcr.io/v2/homebrew/core/openjdk-15.0.2.catalina.bottle.tar.gz
```

However, the Bintray dependency has already been removed from the OpenJDK formula:

https://github.com/Homebrew/homebrew-core/commit/d9511650b68d88543a82e953f09228bd68c73fd4

I found out that more people had a similar issue when installing Homebrew packages, and because of an issue on the very old Homebrew version present in Circle CI images, for now the solution is to run `brew update` before installing a package:

https://github.com/Homebrew/brew/issues/11123