### PR TITLE
clean: Revert workaround from #146

### DIFF
--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -47,11 +47,7 @@ steps:
       name: Download and install sbt
       environment:
         HOMEBREW_NO_AUTO_UPDATE: 1
-      command: |
-        # Call brew update explicitly until Circle CI update their images,
-        # see https://github.com/Homebrew/brew/issues/11123
-        brew update
-        brew install sbt
+      command: brew install sbt
   - run:
       name: Setup AWS Credentials
       command: |


### PR DESCRIPTION
Reverts #146. The previous workaround should no longer be necessary, as CircleCI is already updating Homebrew on macOS images as a workaround on their side:

https://discuss.circleci.com/t/macos-image-users-homebrew-brownout-2021-04-26/39872/2