### PR TITLE
Remove workarounds for Sbt cache invalidation

### DIFF
--- a/src/jobs/publish_docker.yml
+++ b/src/jobs/publish_docker.yml
@@ -41,10 +41,6 @@ parameters:
     description: The AWS region for the deployment
     type: string
     default: eu-west-1
-  unpack_targets:
-    description: If true then unpack targets tarball
-    type: boolean
-    default: false
   cmd:
     description: Docker commands to tag and push the image. If empty then the default commands, which tag with version and push to dockerhub, will be used.
     type: string
@@ -59,23 +55,6 @@ environment:
 steps:
   - attach_workspace:
       at: ~/workdir
-  - when:
-      condition: << parameters.unpack_targets >>
-      steps:
-        - run:
-            name: Unpacking Targets
-            command: |
-              if [[ -d "target" ]] ; then
-                echo "local workspace exists, skipping"
-              elif [[ -f "$HOME/targets.tar.gz" ]] ; then
-                echo "found cache at $HOME"
-                echo "unpacking cache" && tar -xf ~/targets.tar.gz
-              elif [[ -f "./targets.tar.gz" ]] ; then
-                echo "found cache at ."
-                echo "unpacking cache" && tar -xf ./targets.tar.gz
-              else
-                echo "no cache found"
-              fi
   - run_aws:
       cmd_name: Running docker command
       deploy: true

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -36,10 +36,6 @@ parameters:
     description: "Whether to upload the test results back to CircleCI"
     type: boolean
     default: false
-  install_sbt_version:
-    description: "Version of SBT to install. If empty, the system one will be used"
-    type: string
-    default: ""
   no_output_timeout:
     description: "The time to wait for the command without output"
     type: string
@@ -52,15 +48,13 @@ environment:
 steps:
   - attach_workspace:
       at: ~/workdir
-  - when:
-      condition: << parameters.install_sbt_version >>
-      steps:
-        - run:
-            name: Download and install sbt << parameters.install_sbt_version >>
-            command: |
-              wget https://repo.scala-sbt.org/scalasbt/debian/sbt-<< parameters.install_sbt_version >>.deb
-              sudo dpkg -i sbt-<< parameters.install_sbt_version >>.deb
-              rm -f sbt-<< parameters.install_sbt_version >>.deb
+  - run:
+      name: Download and install sbt
+      command: |
+        sbt_version=$(cat project/build.properties | grep sbt.version | sed "s/ *sbt\.version *= *//")
+        wget https://repo.scala-sbt.org/scalasbt/debian/sbt-$sbt_version.deb
+        sudo dpkg -i sbt-$sbt_version.deb
+        rm -f sbt-$sbt_version.deb
   - run:
       name: Setup AWS Credentials
       command: |
@@ -71,15 +65,6 @@ steps:
   - run:
       name: Set OpenJdk
       command: sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-
-  - run:
-      name: Uncompress local targets
-      command: |
-        if [[ -f "targets.tar.gz" ]]; then
-          echo "unpacking persisted workspace" && tar -xf targets.tar.gz
-        else
-          echo "no persisted workspace found"
-        fi
 
   - when:
       condition: << parameters.store_test_results >>
@@ -101,13 +86,7 @@ steps:
   - when:
       condition: << parameters.persist_to_workspace >>
       steps:
-        - run:
-            name: Compressing targets
-            command: |
-              find -name target -type d -exec tar -zcf targets.tar.gz -H posix {} + | true
-              find -name target -type d -exec rm -rf {} + | true
         - persist_to_workspace:
             root: ~/workdir
             paths:
               - '*'
-              - targets.tar.gz

--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -59,14 +59,6 @@ steps:
         cat >> ~/.aws/credentials \<< EOF
         << parameters.credentials_file_content >>
         EOF
-  - run:
-      name: Uncompress local targets
-      command: |
-        if [[ -f "targets.tar.gz" ]]; then
-          echo "unpacking persisted workspace" && tar -xf targets.tar.gz
-        else
-          echo "no persisted workspace found"
-        fi
   - sbt_cached:
       cmd: << parameters.cmd >>
       cache_prefix: << parameters.cache_prefix >>


### PR DESCRIPTION
Sbt 1.4+ solved the issue of wrong cache invalidation in docker environments: https://github.com/sbt/sbt/issues/4168
So this removes the workaround of compressing the targets in workspace between the jobs of a workflow.
The cache tar remains since in CircleCI there isn't a way to select all the `target` directories using a glob.
This also removes the `install_sbt_version` and automatically fetches the sbt version from the `project/build.properties` file.