### PR TITLE
fix: Pin openjdk@8 when installing sbt

### DIFF
--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -56,7 +56,7 @@ steps:
         # Call brew update explicitly until Circle CI update their images,
         # see https://github.com/Homebrew/brew/issues/11123
         brew update
-        brew install sbt
+        brew install openjdk@8 sbt
   - run:
       name: Setup AWS Credentials
       command: |


### PR DESCRIPTION
Fixes the exception `java.lang.UnsupportedOperationException`. For more context see [this Slack thread](https://codacy.slack.com/archives/CA8A4L1DY/p1661948180846799).