### PR TITLE
fix: Correctly set up and pin openjdk@8

### DIFF
--- a/src/jobs/sbt_osx.yml
+++ b/src/jobs/sbt_osx.yml
@@ -56,7 +56,13 @@ steps:
         # Call brew update explicitly until Circle CI update their images,
         # see https://github.com/Homebrew/brew/issues/11123
         brew update
-        brew install openjdk@8 sbt
+        # Pin openjdk@8
+        brew install openjdk@8
+        sudo ln -sfn /usr/local/opt/openjdk@8/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-8.jdk
+        echo 'export PATH="/usr/local/opt/openjdk@8/bin:$PATH"' >> /Users/distiller/.bash_profile
+        export CPPFLAGS="-I/usr/local/opt/openjdk@8/include"
+        # Install sbt without overriding openjdk@8
+        brew install --ignore-dependencies sbt
   - run:
       name: Setup AWS Credentials
       command: |


### PR DESCRIPTION
The update from https://github.com/codacy/codacy-orbs/pull/173 wasn't enough to solve the issue as installing `sbt` reinstalled the openjdk@18 as a dependency:

https://app.circleci.com/pipelines/github/codacy/codacy-faux-pas/49/workflows/4b227b08-309e-415f-82f9-9f2a6c2a7d5c/jobs/308?invite=true#step-102-159