### PR TITLE
feature: Add `steps_before_sbt` to sbt job

### DIFF
--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -10,6 +10,10 @@ parameters:
     description: "SBT command to run"
     type: string
     default: ""
+  steps_before_sbt:
+    description: "Steps to run before Sbt starts"
+    type: steps
+    default: []
   steps:
     description: "SBT steps to run"
     type: steps
@@ -57,6 +61,10 @@ steps:
         else
           echo "no cache found"
         fi
+  - when:
+      condition: <<parameters.steps>>
+      steps:
+        - <<parameters.steps>>
   - when:
       condition: << parameters.use_sbt_native_client >>
       steps:

--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -7,6 +7,10 @@ parameters:
     description: "Steps to run"
     type: steps
     default: []
+  steps_before_sbt:
+    description: "Steps to run before Sbt starts"
+    type: steps
+    default: []
   cmd:
     description: "SBT command to run"
     type: string
@@ -94,6 +98,7 @@ steps:
       steps:
         - sbt_cached:
             steps: << parameters.steps >>
+            steps_before_sbt: << parameters.steps_before_sbt >>
             cmd: << parameters.cmd >>
             cache_prefix: << parameters.cache_prefix >>
             store_test_results_path: ~/workdir
@@ -105,6 +110,7 @@ steps:
       steps:
         - sbt_cached:
             steps: << parameters.steps >>
+            steps_before_sbt: << parameters.steps_before_sbt >>
             cmd: << parameters.cmd >>
             cache_prefix: << parameters.cache_prefix >>
             no_output_timeout:  << parameters.no_output_timeout >>

--- a/src/jobs/sbt_docker.yml
+++ b/src/jobs/sbt_docker.yml
@@ -7,6 +7,10 @@ parameters:
     description: "Steps to run"
     type: steps
     default: []
+  steps_before_sbt:
+    description: "Steps to run before Sbt starts"
+    type: steps
+    default: []
   cache_prefix:
     description: "The prefix of cache to be used"
     type: string
@@ -68,6 +72,7 @@ steps:
             version: 20.10.14
   - sbt_cached:
       steps: << parameters.steps >>
+      steps_before_sbt: << parameters.steps_before_sbt >>
       cache_prefix: << parameters.cache_prefix >>
       no_output_timeout: "10m"
       use_sbt_native_client: << parameters.use_sbt_native_client >>


### PR DESCRIPTION
We want to enable coverage only in CI.
To do that we want to write a custom sbt file before sbt starts.
Since in server-client mode sbt is started by the orb, we need a hook to run some script before sbt starts.

now we can do:
```yaml
steps_before_sbt:
  - run:
      name: "Enable Coverage"
      command: echo "ThisBuild / coverageEnabled := true" > coverage.sbt
steps:
  - run:
      name: "sbt stuff"
      command: sbt compile
```