### PR TITLE
bump: Upgrade ci-aws to 8.2 to get helm ssm -c

### DIFF
--- a/src/executors/aws.yml
+++ b/src/executors/aws.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run AWS commands
 
 docker:
-  - image: codacy/ci-aws:8.1.1
+  - image: codacy/ci-aws:8.2.0
 
 working_directory: ~/workdir


### PR DESCRIPTION
Use ci-aws:8.2.0 in aws executor to have helm clean function available.