### PR TITLE
breaking: bump ci-aws to 9.0.0

### DIFF
--- a/src/executors/aws.yml
+++ b/src/executors/aws.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run AWS commands
 
 docker:
-  - image: codacy/ci-aws:8.2.0
+  - image: codacy/ci-aws:9.0.0
 
 working_directory: ~/workdir


### PR DESCRIPTION
Bump ci-aws to 9.0.0 which adds the latest version of `helm`, v3.10.0.