### PR TITLE
bump: ci-aws to 9.0.2 (upgrades helm push to 0.10.3)

### DIFF
--- a/src/executors/aws.yml
+++ b/src/executors/aws.yml
@@ -2,6 +2,6 @@ description: >
   A docker image to run AWS commands
 
 docker:
-  - image: codacy/ci-aws:9.0.1
+  - image: codacy/ci-aws:9.0.2
 
 working_directory: ~/workdir

--- a/src/jobs/helm_promote.yaml
+++ b/src/jobs/helm_promote.yaml
@@ -46,4 +46,4 @@ steps:
       command: |
         export TMP_DIR_PATH=$(mktemp -d)
         helm pull -d ${TMP_DIR_PATH} --repo << parameters.source_charts_repo_url >> << parameters.chart_name >> --version << parameters.source_version >>
-        helm push ${TMP_DIR_PATH}/*.tgz << parameters.target_charts_repo_url >> -u "<< parameters.target_charts_repo_user >>" -p "<< parameters.target_charts_repo_pass >>" -v  "<< parameters.target_version >>"
+        helm cm-push ${TMP_DIR_PATH}/*.tgz << parameters.target_charts_repo_url >> -u "<< parameters.target_charts_repo_user >>" -p "<< parameters.target_charts_repo_pass >>" -v  "<< parameters.target_version >>"

--- a/src/jobs/helm_push.yaml
+++ b/src/jobs/helm_push.yaml
@@ -54,4 +54,4 @@ steps:
 
         echo "Adding '<< parameters.charts_repo_url >>'"
         helm repo add --username "${CHARTS_REPO_USER}" --password "${CHARTS_REPO_PASS}" codacy << parameters.charts_repo_url >>
-        helm push ${HELM_DIR}/${CHART_NAME} codacy << parameters.push_options >>
+        helm cm-push ${HELM_DIR}/${CHART_NAME} codacy << parameters.push_options >>


### PR DESCRIPTION
Upgrades ci-aws to 9.0.2, which upgrades helm push plugin to 0.10.3.