### PR TITLE
bump: machine executor ubuntu-2004:202107-02->2022.10.1

### DIFF
--- a/src/executors/machine.yml
+++ b/src/executors/machine.yml
@@ -3,6 +3,6 @@ description: >
   https://circleci.com/docs/2.0/executor-types/#using-machine
 
 machine:
-  image: ubuntu-2004:202107-02
+  image: ubuntu-2004:2022.10.1
 
 working_directory: ~/workdir


### PR DESCRIPTION
Upgrade to latest version of ubuntu 20.04. This upgrades docker version and fixes issues building docker images.