### PR TITLE
fix: Update github host keys

### DIFF
--- a/src/jobs/checkout_and_version.yml
+++ b/src/jobs/checkout_and_version.yml
@@ -29,6 +29,14 @@ parameters:
 executor: versioning
 
 steps:
+  - run:
+      name: Update github.com host keys
+      command: |
+        apk add -U openssh-keygen curl jq
+        mkdir -p ~/.ssh
+        if [ -f .ssh/known_hosts ] ; then ssh-keygen -R github.com ; fi
+        curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
+
   - checkout
 
   - run:


### PR DESCRIPTION
Fixes the issue with github.com host key change, and makes this step more resilient by always getting the latest host keys from github.