### PR TITLE
fix: issue with curl binary in checkout_and_version

### DIFF
--- a/src/jobs/checkout_and_version.yml
+++ b/src/jobs/checkout_and_version.yml
@@ -32,7 +32,7 @@ steps:
   - run:
       name: Update github.com host keys
       command: |
-        apk add -U openssh-keygen curl jq
+        apk --upgrade --no-cache add openssh-keygen curl jq
         mkdir -p ~/.ssh
         if [ -f .ssh/known_hosts ] ; then ssh-keygen -R github.com ; fi
         curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts


### PR DESCRIPTION
Fixes an issue where a broken version of the curl binary was being installed and breaking pipeline execution.