### PR TITLE
feature: Add job to support GitHub status check overwrite

### DIFF
--- a/src/jobs/update_dev_env_approval_status_check.yml
+++ b/src/jobs/update_dev_env_approval_status_check.yml
@@ -1,0 +1,60 @@
+# This is a hack to work around CircleCI/Github limitations.
+# Source: https://federicoterzi.com/blog/solving-github-status-stuck-on-pending-with-circlecis-approvals/
+
+description: Overwrites the dev env depploy approval status check to allow for green status checks on github, even if not depploying to a specific dev env
+
+parameters:
+  circleci_job_name:
+    type: string
+    default: "compile_test_deploy/dev_env_01_deploy_approval"
+    description: Pipeline
+
+executor: machine
+
+steps:
+  - run:
+      # Slightly changed from the following source: https://federicoterzi.com/blog/solving-github-status-stuck-on-pending-with-circlecis-approvals/
+      name: Overwrite dev envs depploy approval GitHub status check
+      command: |
+        #!/bin/bash
+        set -e
+
+        CIRCLECI_JOB_NAME="<<parameters.circleci_job_name>>"
+
+        echo "Patching approval job named: $CIRCLECI_JOB_NAME"
+
+        for i in {1..10}
+        do
+          echo "waiting for status to appear..."
+
+          sleep 10
+
+          curl --request GET \
+            --url "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/statuses/$CIRCLE_SHA1" \
+            --header 'Accept: application/vnd.github.v3+json' \
+            --header "Authorization: Bearer $GITHUB_TOKEN" > commit-statuses.json
+
+          cat commit-statuses.json
+          cat commit-statuses.json | jq -r '.[].context' > commit-statuses.txt
+
+          if grep -q "ci/circleci: $CIRCLECI_JOB_NAME" "commit-statuses.txt"; then
+            echo "status appeared, patching the pending state"
+            URL=$(cat commit-statuses.json| jq -r --arg name "$CIRCLECI_JOB_NAME" -c 'map(select(.context | contains($name))) | .[].target_url' | head -1)
+
+            curl --request POST \
+              --url "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/statuses/$CIRCLE_SHA1" \
+              --header 'Accept: application/vnd.github.v3+json' \
+              --header "Authorization: Bearer $GITHUB_TOKEN" \
+              --header 'Content-Type: application/json' \
+              --data '{
+                "state": "success",
+                "target_url": "'"$URL"'",
+                "description": "Patched pending state, please visit circleCI to start the approval.",
+                "context": "ci/circleci: '"$CIRCLECI_JOB_NAME"'"
+              }'
+
+            exit 0
+          fi
+        done
+
+        echo "Could not patch CircleCI approval, timed out"


### PR DESCRIPTION
Some notes:

- Only added one parameter, because the rest can be obtained directly from CircleCI variables
- Bash script based on the solution provided [here](https://federicoterzi.com/blog/solving-github-status-stuck-on-pending-with-circlecis-approvals/)
- Solution only works for one dev environment, needs more tweeks to support multiples (but I think it's fine like this for now, we need to push this forward)