### PR TITLE
fix: Refresh snap on microk8s install

### DIFF
--- a/src/jobs/microk8s_install.yml
+++ b/src/jobs/microk8s_install.yml
@@ -67,6 +67,7 @@ steps:
   - run:
       name: Install microk8s and addon dependencies
       command: |
+        sudo snap refresh
         sudo apt update && sudo apt install nfs-common -y
 
         # enable traffic forwarding, which might not be done automatically for earlier microk8s versions


### PR DESCRIPTION
A recent _snapd_ version (than default 2.51.1) was required to install microk8s 1.25.
Decided to bump all installed snaps instead of only _snapd_.
Currently this leads to an upgrade from _snapd_ 2.51.1 to 2.59.2 and corresponding core.

Opted not to add any new job parameter to select a specific version because snap only makes the most recent stable version channel available to _refresh_, bringing no gain.

The following snaps may be upgraded with this command (**required refresh due to k8s**):
- **core**
- core18
- core20
- lxd
- microk8s
- snapcraft
- **snapd**

This job's limited scope allows easily checking if something breaks.