### PR TITLE
fix: Add default value to `cmd` in `shell` orb

### DIFF
--- a/src/jobs/shell.yml
+++ b/src/jobs/shell.yml
@@ -8,6 +8,7 @@ parameters:
   cmd:
     description: "The command to run"
     type: string
+    default: ""
   persist_to_workspace:
     description: "Whether to persist the workspace or not at the end of the job"
     type: boolean


### PR DESCRIPTION
When I added the `steps` parameter I forgot to set a default for `cmd`