### PR TITLE
fix: Allow running wait_for_workflows in forks

### DIFF
--- a/src/jobs/wait_for_workflows.yml
+++ b/src/jobs/wait_for_workflows.yml
@@ -27,4 +27,4 @@ steps:
   - run:
       name: Wait for running pipelines
       command: |
-        /scripts/wait_for_workflows.py -k $CIRCLE_TOKEN -w $CIRCLE_WORKFLOW_ID -p <<parameters.project_slug>> -b <<parameters.branch>> -t <<parameters.timeout>> -s <<parameters.sleep>>
+        /scripts/wait_for_workflows.py -k "$CIRCLE_TOKEN" -w "$CIRCLE_WORKFLOW_ID" -p <<parameters.project_slug>> -b <<parameters.branch>> -t <<parameters.timeout>> -s <<parameters.sleep>>


### PR DESCRIPTION
`$CIRCLE_TOKEN` is not defined when running PRs from forks quoting the env variable value makes it pass an empty string which is passed as an empty token to the CircleCI API, which works fine when a project is public.

Example: https://app.circleci.com/pipelines/github/codacy/codacy-coverage-reporter/1594/workflows/52c97ab7-77b9-4d01-9a4d-170a59e9c28e/jobs/15313