### PR TITLE
feature: Add `save_cache` parameter to sbt jobs

### DIFF
--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -65,7 +65,10 @@ parameters:
     description: "Version of the docker scout plugin to use"
     type: string
     default: "0.13.1"
-
+  save_cache:
+    description: "Whether to save the cache or not at the end of the job"
+    type: boolean
+    default: true
 
 environment:
   AWS_PROFILE: << parameters.aws_profile >>
@@ -124,6 +127,7 @@ steps:
             store_test_results_path: ~/workdir
             no_output_timeout:  << parameters.no_output_timeout >>
             use_sbt_native_client:  << parameters.use_sbt_native_client >>
+            save_cache: << parameters.save_cache >>
 
   - unless:
       condition: << parameters.store_test_results >>

--- a/src/jobs/sbt_docker.yml
+++ b/src/jobs/sbt_docker.yml
@@ -49,6 +49,10 @@ parameters:
     description: "Version of the docker scout plugin to use"
     type: string
     default: "0.13.1"
+  save_cache:
+    description: "Whether to save the cache or not at the end of the job"
+    type: boolean
+    default: true
 
 environment:
   AWS_PROFILE: << parameters.aws_profile >>
@@ -95,6 +99,7 @@ steps:
       cache_prefix: << parameters.cache_prefix >>
       no_output_timeout: "10m"
       use_sbt_native_client: << parameters.use_sbt_native_client >>
+      save_cache: << parameters.save_cache >>
 
   - when:
       condition: << parameters.persist_to_workspace >>


### PR DESCRIPTION
Currently we spend time to compress and clean the caches every time, even when we don't actually save it.
This PR makes it configurable so the CI does the compression step only when needed.

## Problem example

![Example](https://user-images.githubusercontent.com/5793054/87696517-331dd580-c791-11ea-969c-e3758cf298ba.png)
