### PR TITLE
feature: Avoid saving cache in PRs

### DIFF
--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -136,7 +136,11 @@ steps:
             path: << parameters.store_test_results_path >>
 
   - when:
-      condition: <<parameters.save_cache>>
+      and:
+        - << parameters.save_cache >>
+        - equal:
+          - << pipeline.trigger_parameters.github_app.default_branch >>
+          - << pipeline.trigger_parameters.github_app.branch >>
       steps:
         - run:
             name: CleanCache


### PR DESCRIPTION
This skips the `save_cache` step in branches that are not the default branch of the repository.
In providers different from GitHub this always runs `save_cache` since `"" == ""`.