### PR TITLE
feature: Delete jars before caching targets

### DIFF
--- a/src/commands/sbt_cached.yml
+++ b/src/commands/sbt_cached.yml
@@ -144,6 +144,8 @@ steps:
               set +eo pipefail
               find $HOME/.sbt -name "*.lock" | xargs rm | true
               find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm | true
+              # delete all jars inside target directories
+              find . -name *.jar -type f -exec rm {} \;
               # zip all targets to a single file
               find . -name target -type d -prune -print | zip -r -q -1 -@ ~/targets.zip
 


### PR DESCRIPTION
I was suspicious of the cache we have in worker which is 6 GBs and I found this:
![immagine](https://github.com/codacy/codacy-orbs/assets/5793054/84097bcb-d0ce-4f67-a7a9-a83dc689a621)

So, I'm now cleaning the `jar` before storing the cache, so old jars are dropped.

In worker:

Before:
<img width="618" alt="immagine" src="https://github.com/codacy/codacy-orbs/assets/5793054/0627dd06-2118-4542-b62f-8653d99bad5d">
After:
<img width="616" alt="immagine" src="https://github.com/codacy/codacy-orbs/assets/5793054/0e31dae9-7ff2-49b9-a669-2fb9270d4df2">
