### PR TITLE
Increase no output timeout to 15m

### DIFF
--- a/src/jobs/sbt.yml
+++ b/src/jobs/sbt.yml
@@ -52,7 +52,7 @@ parameters:
   no_output_timeout:
     description: "The time to wait for the command without output"
     type: string
-    default: "10m"
+    default: "15m"
   use_sbt_native_client:
     description: "Use the sbt thin client"
     type: boolean


### PR DESCRIPTION
Increase no output timeout from 10 minutes to 15 minutes. Some builds were hitting the timeout of 10 minutes. See this build for an example: https://app.circleci.com/pipelines/github/codacy/repository-listener/8549/workflows/d60e1ba4-8d9a-4fd5-9ca1-568b6e3fc1d2/jobs/56699