### PR TITLE
Sanitize all-numeric leading-zero short shas in generated versions

### DIFF
--- a/src/jobs/checkout_and_version.yml
+++ b/src/jobs/checkout_and_version.yml
@@ -41,6 +41,14 @@ steps:
       command: /bin/git-version --dev-branch "<<parameters.dev_branch>>" --release-branch "<<parameters.release_branch>>" --version-prefix "<<parameters.version_prefix>>" > .version
 
   - run:
+      name: Sanitize version
+      # git-version emits <base>-<branch>.<n>.sha.<shortsha> on non-release branches.
+      # If the short sha happens to be all-numeric with a leading zero (e.g. sha.0238954244),
+      # it is an invalid SemVer prerelease identifier and helm rejects the chart version.
+      # Prefix such shas with "g" (git-describe convention) to keep the identifier alphanumeric.
+      command: sed -E -i 's/\.sha\.(0[0-9]+)$/.sha.g\1/' .version
+
+  - run:
       name: Current version
       command: cat .version
 


### PR DESCRIPTION
## Problem

`checkout_and_version` writes `.version` from `git-version`, which emits `<base>-<branch>.<n>.sha.<shortsha>` on non-release branches. When a commit's short sha happens to be **all-numeric with a leading zero** (e.g. `sha.0238954244`), the version is invalid SemVer — numeric prerelease identifiers must not have leading zeroes — and helm rejects the chart version:

```
Error: validation: chart.metadata.version "56.4.3-codacywebsitewirelistdirectori.6.sha.0238954244" is invalid
```

Hit on codacy/codacy-website#2172. Rare (needs a 10-hex-digit sha of only digits starting with 0) but kills the pipeline when it lands, and the only workaround is pushing another commit to reroll the sha.

## Fix

Add a `Sanitize version` step right after `Set version`: prefix such shas with `g` (git-describe convention), making the identifier alphanumeric — where leading zeroes are legal.

```
sed -E -i 's/\.sha\.(0[0-9]+)$/.sha.g\1/' .version
```

Applied at the `.version` source so docker tags, chart version, and version.sbt stay consistent. Valid versions (mixed alphanumeric shas, numeric shas without leading zero, release versions) pass through byte-identical.

Alternative considered: fixing codacy/git-version to always emit `sha.g<short>` — cleaner long-term, but changes every generated version string; this orb-side fix only touches the case that is broken today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)